### PR TITLE
Fix caching when resolverNoCache is set to true

### DIFF
--- a/lib/postal.js
+++ b/lib/postal.js
@@ -411,8 +411,8 @@ function getCacher( topic, pubCache, cacheKey, done, envelope ) {
 			if ( !headers.resolverNoCache ) {
 				cache = pubCache[ cacheKey ] = ( pubCache[ cacheKey ] || [] );
 				cache.push( subDef );
+				subDef.cacheKeys.push( cacheKey );
 			}
-			subDef.cacheKeys.push( cacheKey );
 			if ( done ) {
 				done( subDef );
 			}


### PR DESCRIPTION
Since we use unique topic stings the cacheKeys would continue to grow and leak memory.